### PR TITLE
gnuplot.c: add missing header; do not link to unavailable libquadmath on PPC; makefiles: consistently use gfortran

### DIFF
--- a/dspl/Makefile
+++ b/dspl/Makefile
@@ -17,7 +17,7 @@ all: $(RELEASE_DIR)/$(LIB_NAME)\
 
 #Build libdspl.dll or libdspl.so
 $(RELEASE_DIR)/$(LIB_NAME): $(DSPL_OBJ_FILES)  $(BLAS_LIB_NAME) $(LAPACK_DOUBLE_LIB_NAME) $(LAPACK_COMPLEX_LIB_NAME)
-	$(CC) -shared -o $(RELEASE_DIR)/$(LIB_NAME)  $(DSPL_OBJ_FILES) -lm  -L$(LAPACK_RELEASE_DIR) -llapack_complex -llapack_double -L$(BLAS_RELEASE_DIR) -lblas -lgfortran -lquadmath
+	$(CC) -shared -o $(RELEASE_DIR)/$(LIB_NAME)  $(DSPL_OBJ_FILES) -lm -L$(LAPACK_RELEASE_DIR) -llapack_complex -llapack_double -L$(BLAS_RELEASE_DIR) -lblas $(EXTRAFLIBS)
 
 #Compile libdspl obj files from c sources
 $(DSPL_OBJ_DIR)/%.o:$(DSPL_SRC_DIR)/%.c

--- a/dspl/blas/Makefile
+++ b/dspl/blas/Makefile
@@ -1,6 +1,5 @@
 
-
-FORTRAN  = g++
+FORTRAN  = gfortran
 OPTS     = -O3 -fPIC
 DRVOPTS  = $(OPTS)
 NOOPT    =

--- a/dspl/src/gnuplot.c
+++ b/dspl/src/gnuplot.c
@@ -19,6 +19,7 @@
 */
 #include <stdio.h>
 #include <unistd.h>
+#include <string.h>
 #include "dspl.h"
 
 #define GNUPLOT_NO     1
@@ -489,7 +490,3 @@ int DSPL_API gnuplot_open(void** hplot)
         return ERROR_GNUPLOT_CREATE;
     return RES_OK;
 }
-
-
-
-

--- a/make.inc
+++ b/make.inc
@@ -34,6 +34,7 @@ ifeq ($(OS),Windows_NT)
 	DSPL_LIBNAME = libdspl.dll
 	DEF_OS = WIN_OS
 	LFLAGS = -lm
+	EXTRAFLIBS = -lgfortran -lquadmath
 else
 	UNAME_S := $(shell uname -s)
 	UNAME_P := $(shell uname -p)
@@ -41,10 +42,16 @@ else
 		DSPL_LIBNAME = libdspl.so
 		DEF_OS = LINUX_OS
 		LFLAGS = -lm -ldl
+		EXTRAFLIBS = -lgfortran -lquadmath
 	else ifeq ($(UNAME_S),Darwin)
 		DSPL_LIBNAME = libdspl.so
 		DEF_OS = LINUX_OS
 		LFLAGS = -lm -ldl
+		ifeq ($(UNAME_P),powerpc)
+			EXTRAFLIBS = -lgfortran
+		else
+			EXTRAFLIBS = -lgfortran -lquadmath
+		endif
 	endif
 endif
 

--- a/make.inc
+++ b/make.inc
@@ -1,5 +1,5 @@
 CC       = gcc
-FORTRAN  = g++
+FORTRAN  = gfortran
 AR       = ar
 
 # DSPL source and obj file path


### PR DESCRIPTION
Re `gnuplot.c`:

```
src/gnuplot.c: In function 'gnuplot_create':
src/gnuplot.c:215:13: warning: implicit declaration of function 'strcmp' [-Wimplicit-function-declaration]
  215 |         if(!strcmp(argv[1], "--noplot"))
      |             ^~~~~~
src/gnuplot.c:23:1: note: include '<string.h>' or provide a declaration of 'strcmp'
   22 | #include "dspl.h"
  +++ |+#include <string.h>
   23 | 
src/gnuplot.c:237:13: warning: implicit declaration of function 'memset' [-Wimplicit-function-declaration]
  237 |             memset(str, 0, 1024*sizeof(char));
      |             ^~~~~~
src/gnuplot.c:237:13: note: include '<string.h>' or provide a declaration of 'memset'
src/gnuplot.c:237:13: warning: incompatible implicit declaration of built-in function 'memset' [-Wbuiltin-declaration-mismatch]
src/gnuplot.c:237:13: note: include '<string.h>' or provide a declaration of 'memset'
```

The rest should be self-explanatory.