### PR TITLE
Fix implicit function declarations

### DIFF
--- a/dspl/src/dft/fft_cmplx.c
+++ b/dspl/src/dft/fft_cmplx.c
@@ -24,6 +24,7 @@
 #include <float.h>
 
 #include "dspl.h"
+#include "dft.h"
 
 
 #ifdef DOXYGEN_ENGLISH

--- a/dspl/src/dft/ifft_cmplx.c
+++ b/dspl/src/dft/ifft_cmplx.c
@@ -24,6 +24,7 @@
 #include <float.h>
 
 #include "dspl.h"
+#include "dft.h"
 
 
 #ifdef DOXYGEN_ENGLISH

--- a/dspl/src/gnuplot/gnuplot_create.c
+++ b/dspl/src/gnuplot/gnuplot_create.c
@@ -18,6 +18,7 @@
 * along with Foobar.    If not, see <http://www.gnu.org/licenses/>.
 */
 #include <stdio.h>
+#include <string.h>
 #include <unistd.h>
 #include "dspl.h"
 


### PR DESCRIPTION
Fixes the following issue reported in #8:

```
error: implicit declaration of function 'fft_krn' is invalid in C99 [-Werror,-Wimplicit-function-declaration]
```

And the additional errors I saw:

```
error: implicitly declaring library function 'strcmp' with type 'int (const char *, const char *)' [-Werror,-Wimplicit-function-declaration]
error: implicitly declaring library function 'memset' with type 'void *(void *, int, unsigned long)' [-Werror,-Wimplicit-function-declaration]
```